### PR TITLE
Add call number management feature

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -28,7 +28,6 @@ exports.createClient = functions.https.onCall(async (data, context) => {
     companyName,
     contactFullName,
     contactEmail,
-    subscriptionPlan,
   } = data;
 
   // 1. Create a user for the client's primary contact
@@ -56,7 +55,6 @@ exports.createClient = functions.https.onCall(async (data, context) => {
     companyName,
     contactEmail,
     contactFullName,
-    subscriptionPlan,
     createdAt: new Date().toISOString(),
   });
 


### PR DESCRIPTION
## Summary
- remove subscription plan field from client model and Cloud Function
- add mock call number data
- implement call number management tab with CRUD operations
- hook new tab into dashboard navigation
- create modal component for adding and editing numbers

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68823c7734508333b325ef69d139fec1