### PR TITLE
Add full-page client form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "firebase": "^11.10.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.61.1",
         "tailwindcss": "^3.3.3"
       },
       "devDependencies": {
@@ -15527,6 +15528,22 @@
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.61.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
+      "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "firebase": "^11.10.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.61.1",
     "tailwindcss": "^3.3.3"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { auth, functions } from './firebase';
+import { auth } from './firebase';
 import { onAuthStateChanged, signOut } from "firebase/auth";
-import { httpsCallable } from 'firebase/functions';
 import Login from './components/Login';
+import ClientFormPage from './components/ClientFormPage';
 
 
 // --- ICONS (as simple SVG components for self-containment) ---
@@ -50,9 +50,42 @@ const mockGlobalKpis = {
 };
 
 const mockClientListData = [
-    { id: 1, companyName: 'The Modern Agent', contactFullName: 'Stephanie Molenaar', contactEmail: 'steph@tma.com', contactPhone: '555-111-2222', initialCampaign: 'Q3 Investor Outreach', status: 'Active', leads: 482 },
-    { id: 2, companyName: 'Mortgage Broker Inc.', contactFullName: 'Josh Fairhurst', contactEmail: 'josh@mortgage.com', contactPhone: '555-333-4444', initialCampaign: 'New Homebuyer Leads', status: 'Active', leads: 312 },
-    { id: 3, companyName: 'Real Estate Group', contactFullName: 'Braden Smith', contactEmail: 'braden@regroup.com', contactPhone: '555-555-6666', initialCampaign: 'July Listings', status: 'Needs Review', leads: 199 }
+    {
+        id: 1,
+        companyName: 'The Modern Agent',
+        contactFullName: 'Stephanie Molenaar',
+        contactEmail: 'steph@tma.com',
+        contactPhone: '555-111-2222',
+        status: 'Active',
+        leads: 482,
+        members: [
+            { firstName: 'Stephanie', lastName: 'Molenaar', phone: '555-111-2222', email: 'steph@tma.com' }
+        ]
+    },
+    {
+        id: 2,
+        companyName: 'Mortgage Broker Inc.',
+        contactFullName: 'Josh Fairhurst',
+        contactEmail: 'josh@mortgage.com',
+        contactPhone: '555-333-4444',
+        status: 'Active',
+        leads: 312,
+        members: [
+            { firstName: 'Josh', lastName: 'Fairhurst', phone: '555-333-4444', email: 'josh@mortgage.com' }
+        ]
+    },
+    {
+        id: 3,
+        companyName: 'Real Estate Group',
+        contactFullName: 'Braden Smith',
+        contactEmail: 'braden@regroup.com',
+        contactPhone: '555-555-6666',
+        status: 'Needs Review',
+        leads: 199,
+        members: [
+            { firstName: 'Braden', lastName: 'Smith', phone: '555-555-6666', email: 'braden@regroup.com' }
+        ]
+    }
 ];
 
 const mockLeadData = [
@@ -83,6 +116,7 @@ const mockCampaignData = [
     { id: 1, name: 'Q3 Investor Outreach', clientId: 1, clientName: 'The Modern Agent', callNumber: '555-888-1111', status: 'Active' },
     { id: 2, name: 'New Homebuyer Leads', clientId: 2, clientName: 'Mortgage Broker Inc.', callNumber: '555-888-2222', status: 'Active' },
     { id: 3, name: 'July Listings', clientId: 3, clientName: 'Real Estate Group', callNumber: '555-888-3333', status: 'Paused' },
+    { id: 4, name: 'Expired Listings', clientId: null, clientName: '', callNumber: '555-888-4444', status: 'Draft' },
 ];
 
 // Call tracking numbers that can be assigned to clients
@@ -91,6 +125,7 @@ const mockCallNumberData = [
     { id: 2, number: '555-888-2222', clientId: 2 },
     { id: 3, number: '555-888-3333', clientId: 3 },
     { id: 4, number: '555-888-4444', clientId: null },
+    { id: 5, number: '555-888-5555', clientId: null },
 ];
 
 // --- Reusable Components ---
@@ -139,9 +174,10 @@ export default function App() {
 // --- Master Dashboard Component ---
 const MasterDashboard = ({ user }) => {
     const [activeView, setActiveView] = useState('clients');
-    const [isModalOpen, setIsModalOpen] = useState(false);
     const [editingClient, setEditingClient] = useState(null);
+    const [clients, setClients] = useState(mockClientListData);
     const [callNumbers, setCallNumbers] = useState(mockCallNumberData);
+    const [campaigns, setCampaigns] = useState(mockCampaignData);
 
     const addNumber = (number, clientId) => {
         setCallNumbers(prev => [...prev, { id: Date.now(), number, clientId }]);
@@ -159,30 +195,74 @@ const MasterDashboard = ({ user }) => {
         signOut(auth);
     };
     
-    const handleOpenCreateModal = () => {
+    const handleOpenCreateForm = () => {
         setEditingClient(null);
-        setIsModalOpen(true);
+        setActiveView('clientForm');
     };
 
-    const handleOpenEditModal = (client) => {
+    const handleOpenEditForm = (client) => {
         setEditingClient(client);
-        setIsModalOpen(true);
+        setActiveView('clientForm');
+    };
+
+    const handleSaveClient = (data) => {
+        const { numbers: selectedNumbers = [], campaigns: selectedCampaigns = [], ...clientData } = data;
+
+        if (editingClient) {
+            setClients(prev => prev.map(c => (c.id === clientData.id ? clientData : c)));
+        } else {
+            setClients(prev => [...prev, clientData]);
+        }
+
+        // update call numbers assignment
+        setCallNumbers(prev => prev.map(num => {
+            if (selectedNumbers.includes(num.id)) {
+                return { ...num, clientId: clientData.id };
+            }
+            if (num.clientId === clientData.id && !selectedNumbers.includes(num.id)) {
+                return { ...num, clientId: null };
+            }
+            return num;
+        }));
+
+        // update campaign assignment
+        setCampaigns(prev => prev.map(cam => {
+            if (selectedCampaigns.includes(cam.id)) {
+                return { ...cam, clientId: clientData.id, clientName: clientData.companyName };
+            }
+            if (cam.clientId === clientData.id && !selectedCampaigns.includes(cam.id)) {
+                return { ...cam, clientId: null, clientName: '' };
+            }
+            return cam;
+        }));
+
+        setActiveView('clients');
     };
 
     const renderView = () => {
         switch (activeView) {
             case 'overview':
                 return <OverviewTab />;
+            case 'clientForm':
+                return (
+                    <ClientFormPage
+                        client={editingClient}
+                        numbers={callNumbers}
+                        campaigns={campaigns}
+                        onSave={handleSaveClient}
+                        onCancel={() => setActiveView('clients')}
+                    />
+                );
             case 'clients':
-                return <ClientManagementTab onOpenCreateModal={handleOpenCreateModal} onOpenEditModal={handleOpenEditModal} />;
+                return <ClientManagementTab clients={clients} onOpenCreateModal={handleOpenCreateForm} onOpenEditModal={handleOpenEditForm} />;
             case 'numbers':
-                return <CallNumberManagementTab clients={mockClientListData} numbers={callNumbers} onAdd={addNumber} onEdit={updateNumber} onDelete={deleteNumber} />;
+                return <CallNumberManagementTab clients={clients} numbers={callNumbers} onAdd={addNumber} onEdit={updateNumber} onDelete={deleteNumber} />;
             case 'leads':
-                return <LeadManagementTab />;
+                return <LeadManagementTab clients={clients} campaigns={campaigns} />;
             case 'campaigns':
-                return <CampaignManagementTab />;
+                return <CampaignManagementTab campaigns={campaigns} />;
             default:
-                return <ClientManagementTab onOpenCreateModal={handleOpenCreateModal} onOpenEditModal={handleOpenEditModal} />;
+                return <ClientManagementTab clients={clients} onOpenCreateModal={handleOpenCreateForm} onOpenEditModal={handleOpenEditForm} />;
         }
     };
 
@@ -211,7 +291,6 @@ const MasterDashboard = ({ user }) => {
                 {renderView()}
             </main>
 
-            <ClientModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} clientData={editingClient} />
         </div>
     );
 };
@@ -232,18 +311,7 @@ const OverviewTab = () => (
     </div>
 );
 
-const ClientManagementTab = ({ onOpenCreateModal, onOpenEditModal }) => {
-    const [clients, setClients] = useState([]);
-    const [loading, setLoading] = useState(true);
-
-    useEffect(() => {
-        // Simulate fetching data from an API
-        setLoading(true);
-        setTimeout(() => {
-            setClients(mockClientListData);
-            setLoading(false);
-        }, 1000); // 1 second delay to simulate network
-    }, []);
+const ClientManagementTab = ({ clients, onOpenCreateModal, onOpenEditModal }) => {
 
     return (
         <div>
@@ -254,10 +322,7 @@ const ClientManagementTab = ({ onOpenCreateModal, onOpenEditModal }) => {
                 </button>
             </div>
             <div className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
-                {loading ? (
-                    <div className="p-8 text-center text-gray-400">Loading client data...</div>
-                ) : (
-                    <table className="w-full text-left">
+                <table className="w-full text-left">
                         <thead className="bg-gray-900">
                             <tr>
                                 <th className="p-4 text-xs font-semibold uppercase text-gray-400">Client Name</th>
@@ -287,57 +352,38 @@ const ClientManagementTab = ({ onOpenCreateModal, onOpenEditModal }) => {
                             ))}
                         </tbody>
                     </table>
-                )}
-            </div>
+                </div>
         </div>
     );
 };
 
-const CampaignManagementTab = () => {
-    const [campaigns, setCampaigns] = useState([]);
-    const [loading, setLoading] = useState(true);
-
-    useEffect(() => {
-        // Simulate API call
-        setLoading(true);
-        setTimeout(() => {
-            setCampaigns(mockCampaignData);
-            setLoading(false);
-        }, 500);
-    }, []);
-
-    return (
-        <div>
-            <h2 className="text-3xl font-bold text-white mb-6">Campaign Management</h2>
-            <div className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
-                {loading ? (
-                    <div className="p-8 text-center text-gray-400">Loading campaign data...</div>
-                ) : (
-                    <table className="w-full text-left">
-                        <thead className="bg-gray-900">
-                            <tr>
-                                <th className="p-4 text-xs font-semibold uppercase text-gray-400">Campaign</th>
-                                <th className="p-4 text-xs font-semibold uppercase text-gray-400">Client</th>
-                                <th className="p-4 text-xs font-semibold uppercase text-gray-400">Call Number</th>
-                                <th className="p-4 text-xs font-semibold uppercase text-gray-400">Status</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-gray-700">
-                            {campaigns.map(c => (
-                                <tr key={c.id} className="hover:bg-gray-700/50">
-                                    <td className="p-4 font-medium text-white">{c.name}</td>
-                                    <td className="p-4 text-white">{c.clientName}</td>
-                                    <td className="p-4 text-white">{c.callNumber}</td>
-                                    <td className="p-4 text-white">{c.status}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                )}
-            </div>
+const CampaignManagementTab = ({ campaigns }) => (
+    <div>
+        <h2 className="text-3xl font-bold text-white mb-6">Campaign Management</h2>
+        <div className="bg-gray-800 rounded-xl border border-gray-700 overflow-hidden">
+            <table className="w-full text-left">
+                <thead className="bg-gray-900">
+                    <tr>
+                        <th className="p-4 text-xs font-semibold uppercase text-gray-400">Campaign</th>
+                        <th className="p-4 text-xs font-semibold uppercase text-gray-400">Client</th>
+                        <th className="p-4 text-xs font-semibold uppercase text-gray-400">Call Number</th>
+                        <th className="p-4 text-xs font-semibold uppercase text-gray-400">Status</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-700">
+                    {campaigns.map(c => (
+                        <tr key={c.id} className="hover:bg-gray-700/50">
+                            <td className="p-4 font-medium text-white">{c.name}</td>
+                            <td className="p-4 text-white">{c.clientId ? c.clientName : 'Unassigned'}</td>
+                            <td className="p-4 text-white">{c.callNumber}</td>
+                            <td className="p-4 text-white">{c.status}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
         </div>
-    );
-};
+    </div>
+);
 
 const CallNumberManagementTab = ({ clients, numbers, onAdd, onEdit, onDelete }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -387,7 +433,7 @@ const CallNumberManagementTab = ({ clients, numbers, onAdd, onEdit, onDelete }) 
     );
 };
 
-const LeadManagementTab = () => {
+const LeadManagementTab = ({ clients, campaigns }) => {
     const [search, setSearch] = useState('');
     const [clientFilter, setClientFilter] = useState('');
     const [campaignFilter, setCampaignFilter] = useState('');
@@ -425,13 +471,13 @@ const LeadManagementTab = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <select value={clientFilter} onChange={e => setClientFilter(e.target.value)} className="w-full px-3 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg">
                         <option value="">All Clients</option>
-                        {mockClientListData.map(c => (
+                        {clients.map(c => (
                             <option key={c.id} value={c.companyName}>{c.companyName}</option>
                         ))}
                     </select>
                     <select value={campaignFilter} onChange={e => setCampaignFilter(e.target.value)} className="w-full px-3 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg">
                         <option value="">All Campaigns</option>
-                        {mockCampaignData.map(c => (
+                        {campaigns.map(c => (
                             <option key={c.id} value={c.name}>{c.name}</option>
                         ))}
                     </select>
@@ -468,110 +514,6 @@ const LeadManagementTab = () => {
     );
 };
 
-// --- Modal Component ---
-const ClientModal = ({ isOpen, onClose, clientData }) => {
-    const [formData, setFormData] = useState({});
-
-    useEffect(() => {
-        if (clientData) {
-            setFormData(clientData);
-        } else {
-            setFormData({
-                companyName: '',
-                contactFullName: '',
-                contactEmail: '',
-                contactPhone: '',
-                initialCampaign: '',
-                callNumber: ''
-            });
-        }
-    }, [clientData, isOpen]);
-
-    const handleChange = (e) => {
-        const { name, value } = e.target;
-        setFormData(prev => ({ ...prev, [name]: value }));
-    };
-
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        if (clientData) {
-            alert(`Simulating API call to UPDATE client...\n\nData Sent:\n${JSON.stringify(formData, null, 2)}`);
-            onClose();
-            return;
-        }
-
-        try {
-            const createClient = httpsCallable(functions, 'createClient');
-            const result = await createClient({
-                companyName: formData.companyName,
-                contactFullName: formData.contactFullName,
-                contactEmail: formData.contactEmail,
-            });
-            alert(result.data.message);
-
-            if (formData.initialCampaign) {
-                const createCampaign = httpsCallable(functions, 'createCampaign');
-                await createCampaign({
-                    clientId: result.data.clientId,
-                    name: formData.initialCampaign,
-                    callNumber: formData.callNumber,
-                });
-            }
-        } catch (err) {
-            console.error('Error creating client:', err);
-            alert('Failed to create client');
-        }
-        onClose();
-    };
-    
-    if (!isOpen) return null;
-
-    const isEditMode = !!clientData;
-
-    return (
-        <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50">
-            <form onSubmit={handleSubmit} className="bg-gray-800 rounded-2xl shadow-2xl w-full max-w-lg p-8 border border-gray-700">
-                <h2 className="text-2xl font-bold text-white mb-6">{isEditMode ? 'Edit Client' : 'Onboard New Client'}</h2>
-                <div className="space-y-4">
-                    <div>
-                        <label className="text-sm font-medium text-gray-300">Company Name</label>
-                        <input name="companyName" type="text" required value={formData.companyName} onChange={handleChange} className="mt-1 w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                            <label className="text-sm font-medium text-gray-300">Primary Contact Full Name</label>
-                            <input name="contactFullName" type="text" required value={formData.contactFullName} onChange={handleChange} className="mt-1 w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-                        </div>
-                        <div>
-                            <label className="text-sm font-medium text-gray-300">Primary Contact Phone</label>
-                            <input name="contactPhone" type="tel" value={formData.contactPhone} onChange={handleChange} className="mt-1 w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-                        </div>
-                    </div>
-                     <div>
-                        <label className="text-sm font-medium text-gray-300">Primary Contact Email</label>
-                        <input name="contactEmail" type="email" required value={formData.contactEmail} onChange={handleChange} className="mt-1 w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-                    </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                            <label className="text-sm font-medium text-gray-300">Initial Campaign Name</label>
-                            <input name="initialCampaign" type="text" required value={formData.initialCampaign} onChange={handleChange} className="mt-1 w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-                        </div>
-                        <div>
-                            <label className="text-sm font-medium text-gray-300">Call Tracking Number</label>
-                            <input name="callNumber" type="text" value={formData.callNumber} onChange={handleChange} className="mt-1 w-full px-4 py-3 bg-gray-700 text-white border border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-                        </div>
-                    </div>
-                </div>
-                <div className="mt-8 flex justify-end space-x-4">
-                    <button type="button" onClick={onClose} className="py-2 px-4 rounded-lg text-gray-300 hover:bg-gray-700">Cancel</button>
-                    <button type="submit" className="bg-indigo-600 text-white font-semibold py-2 px-5 rounded-lg hover:bg-indigo-700">
-                        {isEditMode ? 'Save Changes' : 'Create Client & Provision'}
-                    </button>
-                </div>
-            </form>
-        </div>
-    );
-};
 
 const LeadModal = ({ lead, onClose, onSave }) => {
     const [disposition, setDisposition] = useState('');

--- a/src/components/ClientFormPage.js
+++ b/src/components/ClientFormPage.js
@@ -1,0 +1,160 @@
+import React, { useEffect, useState } from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+
+export default function ClientFormPage({ client, numbers, campaigns, onSave, onCancel }) {
+  const { register, control, handleSubmit, setValue } = useForm({
+    defaultValues: {
+      clientName: '',
+      companyName: '',
+      contactEmail: '',
+      contactPhone: '',
+      contactPerson: '',
+      members: []
+    }
+  });
+  const { fields: memberFields, append, remove } = useFieldArray({ control, name: 'members' });
+
+  const [assignedNumbers, setAssignedNumbers] = useState([]);
+  const [assignedCampaigns, setAssignedCampaigns] = useState([]);
+  const [newNumber, setNewNumber] = useState('');
+  const [newCampaign, setNewCampaign] = useState('');
+
+  useEffect(() => {
+    if (client) {
+      setValue('clientName', client.contactFullName || client.clientName || '');
+      setValue('companyName', client.companyName || '');
+      setValue('contactEmail', client.contactEmail || '');
+      setValue('contactPhone', client.contactPhone || '');
+      if (client.contactPerson) setValue('contactPerson', client.contactPerson);
+      if (client.members) {
+        setValue('members', client.members);
+      }
+      setAssignedNumbers(numbers.filter(n => n.clientId === client.id).map(n => n.id));
+      setAssignedCampaigns(campaigns.filter(c => c.clientId === client.id).map(c => c.id));
+    }
+  }, [client, setValue, numbers, campaigns]);
+
+  const availableNumbers = numbers.filter(n => n.clientId === null || assignedNumbers.includes(n.id));
+  const availableCampaigns = campaigns.filter(c => c.clientId === null || assignedCampaigns.includes(c.id));
+
+  const addNumber = () => {
+    if (newNumber && !assignedNumbers.includes(parseInt(newNumber, 10))) {
+      setAssignedNumbers(prev => [...prev, parseInt(newNumber, 10)]);
+      setNewNumber('');
+    }
+  };
+
+  const addCampaign = () => {
+    if (newCampaign && !assignedCampaigns.includes(parseInt(newCampaign, 10))) {
+      setAssignedCampaigns(prev => [...prev, parseInt(newCampaign, 10)]);
+      setNewCampaign('');
+    }
+  };
+
+  const onSubmit = (data) => {
+    const payload = {
+      id: client?.id || Date.now(),
+      status: client?.status || 'Active',
+      leads: client?.leads || 0,
+      ...data,
+      members: data.members,
+      numbers: assignedNumbers,
+      campaigns: assignedCampaigns
+    };
+    onSave(payload);
+  };
+
+  return (
+    <div className="p-8">
+      <h2 className="text-3xl font-bold text-white mb-6">{client ? 'Edit Client' : 'Create Client'}</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+        <section className="bg-gray-800 p-6 rounded-xl border border-gray-700 space-y-4">
+          <h3 className="text-xl text-white font-semibold">Contact Information</h3>
+          <div>
+            <label className="text-sm font-medium text-gray-300">Client Name</label>
+            <input {...register('clientName', { required: true })} className="mt-1 w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg" />
+          </div>
+          <div>
+            <label className="text-sm font-medium text-gray-300">Company Name</label>
+            <input {...register('companyName', { required: true })} className="mt-1 w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg" />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="text-sm font-medium text-gray-300">Contact Email</label>
+              <input type="email" {...register('contactEmail', { required: true })} className="mt-1 w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg" />
+            </div>
+            <div>
+              <label className="text-sm font-medium text-gray-300">Contact Phone</label>
+              <input type="tel" {...register('contactPhone')} className="mt-1 w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg" />
+            </div>
+          </div>
+          <div>
+            <label className="text-sm font-medium text-gray-300">Assigned Contact Person</label>
+            <input {...register('contactPerson')} className="mt-1 w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg" />
+          </div>
+        </section>
+
+        <section className="bg-gray-800 p-6 rounded-xl border border-gray-700 space-y-4">
+          <h3 className="text-xl text-white font-semibold">JustCall Number Management</h3>
+          <div className="space-y-2">
+            {assignedNumbers.map(id => (
+              <div key={id} className="flex items-center justify-between bg-gray-700 p-2 rounded-lg">
+                <span className="text-white">{numbers.find(n => n.id === id)?.number}</span>
+                <button type="button" onClick={() => setAssignedNumbers(prev => prev.filter(n => n !== id))} className="text-red-400 hover:underline">Remove</button>
+              </div>
+            ))}
+          </div>
+          <div className="flex space-x-2 items-end">
+            <select value={newNumber} onChange={e => setNewNumber(e.target.value)} className="w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg">
+              <option value="">Select number</option>
+              {availableNumbers.filter(n => n.clientId === null).map(num => (
+                <option key={num.id} value={num.id}>{num.number}</option>
+              ))}
+            </select>
+            <button type="button" onClick={addNumber} className="py-2 px-4 rounded-lg text-gray-300 hover:bg-gray-700">Add</button>
+          </div>
+        </section>
+
+        <section className="bg-gray-800 p-6 rounded-xl border border-gray-700 space-y-4">
+          <h3 className="text-xl text-white font-semibold">Campaigns Management</h3>
+          <div className="space-y-2">
+            {assignedCampaigns.map(id => (
+              <div key={id} className="flex items-center justify-between bg-gray-700 p-2 rounded-lg">
+                <span className="text-white">{campaigns.find(c => c.id === id)?.name}</span>
+                <button type="button" onClick={() => setAssignedCampaigns(prev => prev.filter(c => c !== id))} className="text-red-400 hover:underline">Remove</button>
+              </div>
+            ))}
+          </div>
+          <div className="flex space-x-2 items-end">
+            <select value={newCampaign} onChange={e => setNewCampaign(e.target.value)} className="w-full px-4 py-2 bg-gray-700 text-white border border-gray-600 rounded-lg">
+              <option value="">Select campaign</option>
+              {availableCampaigns.filter(c => c.clientId === null).map(c => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+            <button type="button" onClick={addCampaign} className="py-2 px-4 rounded-lg text-gray-300 hover:bg-gray-700">Add</button>
+          </div>
+        </section>
+
+        <section className="bg-gray-800 p-6 rounded-xl border border-gray-700 space-y-4">
+          <h3 className="text-xl text-white font-semibold">Members Management</h3>
+          {memberFields.map((field, index) => (
+            <div key={field.id} className="grid grid-cols-1 md:grid-cols-4 gap-2 items-end bg-gray-700 p-2 rounded-lg">
+              <input {...register(`members.${index}.firstName`)} placeholder="First" className="px-2 py-1 bg-gray-600 text-white border border-gray-500 rounded" />
+              <input {...register(`members.${index}.lastName`)} placeholder="Last" className="px-2 py-1 bg-gray-600 text-white border border-gray-500 rounded" />
+              <input {...register(`members.${index}.phone`)} placeholder="Phone" className="px-2 py-1 bg-gray-600 text-white border border-gray-500 rounded" />
+              <input {...register(`members.${index}.email`)} placeholder="Email" className="px-2 py-1 bg-gray-600 text-white border border-gray-500 rounded" />
+              <button type="button" onClick={() => remove(index)} className="text-red-400 hover:underline md:col-span-4 text-left">Remove</button>
+            </div>
+          ))}
+          <button type="button" onClick={() => append({ firstName: '', lastName: '', phone: '', email: '' })} className="py-2 px-4 rounded-lg text-gray-300 hover:bg-gray-700">Add Member</button>
+        </section>
+
+        <div className="flex justify-end space-x-4">
+          <button type="button" onClick={onCancel} className="py-2 px-4 rounded-lg text-gray-300 hover:bg-gray-700">Cancel</button>
+          <button type="submit" className="bg-indigo-600 text-white font-semibold py-2 px-5 rounded-lg hover:bg-indigo-700">Save</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/mockApi.js
+++ b/src/mockApi.js
@@ -1,0 +1,26 @@
+export function getCampaigns() {
+  return Promise.resolve([
+    { id: 1, name: 'Q3 Investor Outreach', clientId: 1 },
+    { id: 2, name: 'New Homebuyer Leads', clientId: 2 },
+    { id: 3, name: 'July Listings', clientId: 3 },
+    { id: 4, name: 'Expired Listings', clientId: null }
+  ]);
+}
+
+export function getJustCallNumbers() {
+  return Promise.resolve([
+    { id: 1, number: '555-888-1111', clientId: 1 },
+    { id: 2, number: '555-888-2222', clientId: 2 },
+    { id: 3, number: '555-888-3333', clientId: 3 },
+    { id: 4, number: '555-888-4444', clientId: null },
+    { id: 5, number: '555-888-5555', clientId: null }
+  ]);
+}
+
+export function getMembers() {
+  return Promise.resolve([
+    { id: 1, firstName: 'Alice', lastName: 'Johnson', phone: '555-111-0001', email: 'alice@example.com' },
+    { id: 2, firstName: 'Bob', lastName: 'Smith', phone: '555-111-0002', email: 'bob@example.com' },
+    { id: 3, firstName: 'Carol', lastName: 'Lee', phone: '555-111-0003', email: 'carol@example.com' }
+  ]);
+}


### PR DESCRIPTION
## Summary
- add a mock API module with sample data functions
- introduce `ClientFormPage` using react-hook-form to manage client details
- manage clients in `MasterDashboard` state and navigate to the new form
- remove old client modal and cleanup
- install `react-hook-form`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68824040a9c48333b15e91f559c31165