### PR TITLE
Improve error message when creating a client

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -173,7 +173,8 @@ const MasterDashboard = ({ user }) => {
                 setNotification({ type: 'success', text: 'Client created successfully.' });
             } catch (err) {
                 console.error('Failed to create client', err);
-                setNotification({ type: 'error', text: 'Failed to create client.' });
+                const message = err && err.message ? err.message : String(err);
+                setNotification({ type: 'error', text: `Failed to create client: ${message}` });
             }
         }
         setActiveView('clients');


### PR DESCRIPTION
## Summary
- show the actual error message if client creation fails so users know why

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688325cedac883339fcd2144aabe3999