### PR TITLE
Add error handling to createCampaign

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -135,12 +135,16 @@ exports.createCampaign = functions.https.onCall(async (data, context) => {
   ]);
   const campaignId = `campaign_${Date.now()}`;
 
-  await campaignsTable.insert({
-    campaignId,
-    name,
-    callNumber,
-    createdAt: new Date().toISOString(),
-  });
+  try {
+    await campaignsTable.insert({
+      campaignId,
+      name,
+      callNumber,
+      createdAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    throw new functions.https.HttpsError("internal", err.message);
+  }
 
   return {
     status: "success",


### PR DESCRIPTION
## Summary
- handle errors when inserting campaign rows

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68832807b38083338d6319e53a7417db