### PR TITLE
Fix Cloud Functions runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,36 @@ This project is a small React + Firebase prototype for managing clients and lead
 This repo is intended as a starting point and uses Tailwind CSS for styling. The dashboard now loads all data directly from BigQuery via Cloud Functions and no longer relies on mock objects.
 The Cloud Functions expect credentials with access to BigQuery. Deploy using a service account that has permission to create datasets and tables.
 
+### Cloud Functions runtime
+
+Cloud Functions need a supported Node.js version to deploy successfully.
+The `functions/package.json` file specifies the version under the `engines` key.
+Make sure it is set to `"18"` (or another supported version) before running
+`firebase deploy`.
+
 ### Using BigQuery for live data
 
 1. Create a Google Cloud service account with permissions to manage BigQuery datasets and tables.
-2. Download its JSON key file and set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of this file when running the Firebase functions locally or deploying.
-3. The `getMasterData` Cloud Function will automatically create the `master_data` dataset and the `clients`, `call_numbers`, `campaigns` and `leads` tables if they do not exist.
-4. When the React app loads it calls this function along with `getGlobalKpis` to pull the latest data from BigQuery.
+2. Download its JSON key file.
+3. When deploying Cloud Functions, prepend the deploy command with the environment variable so the Firebase CLI can authenticate:
+
+   ```bash
+   GOOGLE_APPLICATION_CREDENTIALS=./functions/bigquery-key.json firebase deploy --only functions
+   ```
+
+   The variable defined in `.env.local` is only used by the React app and will **not** be read by the Firebase CLI.
+4. The `getMasterData` Cloud Function will automatically create the `master_data` dataset and the `clients`, `call_numbers`, `campaigns` and `leads` tables if they do not exist.
+5. When the React app loads it calls this function along with `getGlobalKpis` to pull the latest data from BigQuery.
+
+### Testing your BigQuery credentials
+
+If you want to verify that your service account works before deploying, run the helper script:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS=./functions/bigquery-key.json node functions/testBigQueryConnection.js
+```
+
+It will attempt to list your BigQuery datasets and print a success message if the credentials are valid.
 
 ## Updating your local copy
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "18"
   },
   "main": "index.js",
   "dependencies": {

--- a/functions/testBigQueryConnection.js
+++ b/functions/testBigQueryConnection.js
@@ -1,0 +1,14 @@
+const { BigQuery } = require('@google-cloud/bigquery');
+
+async function main() {
+  const bigquery = new BigQuery();
+  try {
+    const [datasets] = await bigquery.getDatasets();
+    console.log(`BigQuery connection successful. Found ${datasets.length} datasets.`);
+  } catch (err) {
+    console.error('Unable to connect to BigQuery:', err.message);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- set the Firebase Functions runtime to Node 18
- add README section explaining the supported runtime
- clarify how to deploy with a BigQuery service account
- add a helper script to verify credentials

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68832aac69c0833382ec9e3d6eddea45