### PR TITLE
Remove undefined campaign state hooks

### DIFF
--- a/src/components/MasterDashboard.js
+++ b/src/components/MasterDashboard.js
@@ -218,7 +218,6 @@ export default function MasterDashboard({ user }) {
             clients={clients}
             numbers={callNumbers}
             onAdd={addCampaign}
-            onOpen={() => { setEditingCampaign(null); setCampaignModalOpen(true); }}
           />
         );
       default:


### PR DESCRIPTION
## Summary
- eliminate unused `setEditingCampaign` and `setCampaignModalOpen` references

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6884a3535468833392d1dd87ca5b347d